### PR TITLE
Bump matterfirpc version to 0.2.50

### DIFF
--- a/ports/matterfirpc/portfile.cmake
+++ b/ports/matterfirpc/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_git(
   URL
   ssh://git@github.com/matterfi/matterfirpc.git
   REF
-  a4475b85c9d9e29f011e3a044ec46633cfa9e1b4
+  c2f2d0fe0fe2ff413ff1faf7ed2f302d1ec6c1b2
   HEAD_REF
   master)
 

--- a/ports/matterfirpc/vcpkg.json
+++ b/ports/matterfirpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "matterfirpc",
-    "version": "0.2.49",
+    "version": "0.2.50",
     "port-version": 0,
     "features": {
         "deploy": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -21,7 +21,7 @@
             "port-version": 0
         },
         "matterfirpc": {
-            "baseline": "0.2.49",
+            "baseline": "0.2.50",
             "port-version": 0
         }
     }

--- a/versions/m-/matterfirpc.json
+++ b/versions/m-/matterfirpc.json
@@ -1,6 +1,11 @@
 {
     "versions": [
         {
+            "version": "0.2.50",
+            "port-version": 0,
+            "git-tree": "fb77686b647fff6a278b9f519a611b775dcc443a"
+        },
+        {
             "version": "0.2.49",
             "port-version": 0,
             "git-tree": "97a78024d9f911685c9a28fcd936ad1b286e73cc"


### PR DESCRIPTION
## Summary
- Bump matterfirpc from 0.2.49 to 0.2.50
- Update REF to commit `c2f2d0fe0fe2ff413ff1faf7ed2f302d1ec6c1b2`
- Update baseline and versions index with correct git-tree