### PR TITLE
opentxs: add Emscripten/WASM support

### DIFF
--- a/ports/opentxs/Filesystem.internal.wasm.cpp
+++ b/ports/opentxs/Filesystem.internal.wasm.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2010-2024 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "opentxs/util/storage/driver/Filesystem.internal.hpp"  // IWYU pragma: associated
+
+#include "opentxs/external/platform/posix.hpp"
+
+namespace opentxs::inline util::storage::driver
+{
+auto Filesystem::sync(DescriptorType::handle_type fd) noexcept -> bool
+{
+    return 0 == ::fsync(fd);
+}
+}  // namespace opentxs::inline util::storage::driver

--- a/ports/opentxs/ZeroMQ.internal.wasm.cpp
+++ b/ports/opentxs/ZeroMQ.internal.wasm.cpp
@@ -1,0 +1,154 @@
+// Copyright (c) 2010-2024 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Patched for WASM/Emscripten: ZMQ inproc socket connect can fail in worker
+// threads. Rather than calling std::terminate(), fall back to Console backend.
+
+#include "opentxs/util/log/backend/ZeroMQ.internal.hpp"  // IWYU pragma: associated
+
+#include "opentxs/api/session/Endpoints.internal.hpp"
+#include "opentxs/external/boost/scope.hpp"
+#include "opentxs/external/stl.hpp"
+#include "opentxs/network/zeromq/Context.internal.hpp"
+#include "opentxs/network/zeromq/Socket.hpp"
+#include "opentxs/network/zeromq/Socket.internal.hpp"
+#include "opentxs/network/zeromq/message/Message.hpp"
+#include "opentxs/network/zeromq/socket/Type.hpp"  // IWYU pragma: keep
+#include "opentxs/network/zeromq/socket/Types.hpp"
+#include "opentxs/util/WorkType.internal.hpp"
+#include "opentxs/util/alloc/Strategy.hpp"
+#include "opentxs/util/log/backend/Console.internal.hpp"
+
+namespace opentxs::inline util::log::backend
+{
+ZeroMQ::ZeroMQ() noexcept
+    : data_(std::make_shared<GuardedData>())
+{
+    if (nullptr == data_) {
+        std::abort();
+    }
+}
+
+auto ZeroMQ::Get() noexcept -> ZeroMQ&
+{
+    static auto instance = ZeroMQ{};
+
+    return instance;
+}
+
+auto ZeroMQ::make_logger(ZMQ zmq) noexcept -> std::shared_ptr<Backend>
+{
+    using enum network::zeromq::socket::Type;
+
+    if (nullptr == zmq) {
+        std::abort();
+    }
+
+    struct Logger final : public Backend {
+        std::weak_ptr<network::zeromq::internal::Context const> zmq_;
+        network::zeromq::Socket socket_;
+
+        auto Print(
+            std::thread::id thread,
+            std::string_view message,
+            int level,
+            bool isError,
+            bool isFatal) noexcept -> void final
+        {
+            auto const threadID = [&] {
+                auto out = std::stringstream{};
+                out << thread;
+
+                return out.str();
+            }();
+
+            if (auto zmq = zmq_.lock(); nullptr != zmq) {
+                std::ignore = socket_.Internal().SendDeferred([&]() {
+                    auto out = MakeWork(ot_zmq_log_message_);
+                    out.AddFrame(level);
+                    out.AddFrame(message.data(), message.size());
+                    out.AddFrame(threadID.data(), threadID.size());
+                    out.AddFrame(isError);
+                    out.AddFrame(isFatal);
+
+                    return out;
+                }());
+            } else {
+                Console().Get().Print(thread, message, level, isError, isFatal);
+            }
+        }
+
+        Logger(ZMQ zmq, network::zeromq::Socket socket) noexcept
+            : zmq_(zmq)
+            , socket_(std::move(socket))
+        {
+        }
+    };
+
+    auto socket = zmq->MakeSocket(Push, alloc::Strategy{});  // TODO allocator
+
+    if (false == socket.Internal().SetOutgoingHWM(0)) {
+        return std::make_shared<Console>();
+    }
+
+    using api::session::internal::Endpoints;
+
+    if (false == socket.ConnectNullTerminated(Endpoints::LogBackend().data())) {
+        return std::make_shared<Console>();
+    }
+
+    return std::make_shared<Logger>(zmq, std::move(socket));
+}
+
+auto ZeroMQ::Print(
+    std::thread::id const thread,
+    std::string_view const message,
+    int const level,
+    bool const isError,
+    bool const isFatal) noexcept -> void
+{
+    Console::Get().Print(thread, message, level, isError, isFatal);
+}
+
+auto ZeroMQ::Register(ZMQ zmq) noexcept -> void
+{
+    auto handle = data_->lock();
+    auto& data = *handle;
+    data.zmq_ = zmq;
+    data.map_.clear();
+}
+
+auto ZeroMQ::Thread() noexcept -> std::shared_ptr<Backend>
+{
+    auto const id = std::this_thread::get_id();
+    static thread_local auto cleanup = boost::scope::make_scope_exit(
+        [id, data = data_] { data->lock()->map_.erase(id); });
+    auto handle = data_->lock();
+    auto& data = *handle;
+    auto zmq = data.zmq_.lock();
+    auto& map = data.map_;
+
+    if (zmq) {
+        if (auto i = map.find(id); map.end() != i) {
+
+            return i->second;
+        } else {
+            std::tie(i, std::ignore) = map.try_emplace(id, make_logger(zmq));
+
+            if (nullptr == i->second) {
+                std::abort();
+            }
+
+            return i->second;
+        }
+    } else {
+        map.clear();
+
+        return std::make_shared<Console>();
+    }
+}
+
+ZeroMQ::~ZeroMQ() = default;
+}  // namespace opentxs::inline util::log::backend

--- a/ports/opentxs/portfile.cmake
+++ b/ports/opentxs/portfile.cmake
@@ -76,6 +76,19 @@ vcpkg_execute_in_download_mode(
   --recursive
 )
 
+if(VCPKG_TARGET_IS_EMSCRIPTEN OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  file(
+    COPY_FILE
+    "${CMAKE_CURRENT_LIST_DIR}/Filesystem.internal.wasm.cpp"
+    "${SOURCE_PATH}/src/opentxs/util/storage/driver/Filesystem.internal.wasm.cpp"
+  )
+  file(
+    COPY_FILE
+    "${CMAKE_CURRENT_LIST_DIR}/ZeroMQ.internal.wasm.cpp"
+    "${SOURCE_PATH}/src/opentxs/util/log/backend/ZeroMQ.internal.cpp"
+  )
+endif()
+
 if("test" IN_LIST FEATURES)
  vcpkg_execute_in_download_mode(
    COMMAND
@@ -146,6 +159,16 @@ if(VCPKG_TARGET_IS_IOS)
   set(OPENTXS_TARGET_IS_IOS "-DOPENTXS_TARGET_IS_IOS=ON")
 endif()
 
+if(VCPKG_TARGET_IS_EMSCRIPTEN OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  string(APPEND VCPKG_CXX_FLAGS " -fexceptions")
+  set(OPENTXS_EMSCRIPTEN_OPTIONS
+    -DOT_WITH_BLOCKCHAIN=OFF
+    -DOT_STORAGE_LMDB=OFF
+    -DOT_STORAGE_SQLITE=OFF
+    -DOT_STORAGE_FS=ON
+  )
+endif()
+
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -182,6 +205,7 @@ vcpkg_cmake_configure(
   -DOPENTXS_HIDE_SYMBOLS=ON
   -DOT_ENABLE_MODULE=OFF
   -DOPENTXS_STANDALONE=ON
+  ${OPENTXS_EMSCRIPTEN_OPTIONS}
   ${FEATURE_OPTIONS}
   -Dopentxs_GIT_VERSION=${OT_VERSION_STRING}
   "${OPENTXS_PROTOBUF_PROTOC_EXECUTABLE}"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
         },
         "opentxs": {
             "baseline": "1.264.0",
-            "port-version": 0
+            "port-version": 1
         },
         "matterfirpc": {
             "baseline": "0.2.58",

--- a/versions/o-/opentxs.json
+++ b/versions/o-/opentxs.json
@@ -2,6 +2,11 @@
     "versions": [
         {
             "version": "1.264.0",
+            "port-version": 1,
+            "git-tree": "abc3d45afcc76b98ad396acd5af73789e80a6b24"
+        },
+        {
+            "version": "1.264.0",
             "port-version": 0,
             "git-tree": "2bcc0956d16bfed52fc99a9031d21b8887f52f4b"
         },


### PR DESCRIPTION
## Summary

- Patches ZeroMQ log backend to fall back to `Console` instead of calling `std::terminate()` when inproc socket connect fails in worker threads (silent crash in WASM builds)
- Adds `Filesystem.internal.wasm.cpp` — sync stub for WASM filesystem storage driver
- Disables blockchain, LMDB, SQLite for Emscripten; enables filesystem storage and `-fexceptions`

## Details

In Emscripten builds with pthreads, ZMQ inproc socket `connect()` can fail in worker threads. The original code called `std::terminate()` in the `Logger` constructor with no preceding log output, making the crash invisible. The patch moves socket setup out of the constructor into `make_logger()` and returns a `Console` backend fallback on failure.

All changes are behind `VCPKG_TARGET_IS_EMSCRIPTEN` guards — no impact on Linux/Windows/iOS/Android builds.