### PR TITLE
Bump matterfirpc version to 0.2.59

### DIFF
--- a/ports/matterfirpc/portfile.cmake
+++ b/ports/matterfirpc/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_git(
   URL
   ssh://git@github.com/matterfi/matterfirpc.git
   REF
-  7423a2fcfd9d84b2083211992a5c2e7fdcc603ce
+  f49e2aa0d8b93eaead5f85ed1295d3fb98b4c143
   HEAD_REF
   master)
 

--- a/ports/matterfirpc/vcpkg.json
+++ b/ports/matterfirpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "name": "matterfirpc",
-    "version": "0.2.58",
-    "port-version": 1,
+    "version": "0.2.59",
+    "port-version": 0,
     "features": {
         "deploy": {
             "description": "Implement Contract::deploy",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -21,8 +21,8 @@
             "port-version": 0
         },
         "matterfirpc": {
-            "baseline": "0.2.58",
-            "port-version": 1
+            "baseline": "0.2.59",
+            "port-version": 0
         }
     }
 }

--- a/versions/m-/matterfirpc.json
+++ b/versions/m-/matterfirpc.json
@@ -1,6 +1,11 @@
 {
     "versions": [
         {
+            "version": "0.2.59",
+            "port-version": 0,
+            "git-tree": "31483450629e2e36debbc8ca4a3777eda79f9fe1"
+        },
+        {
             "version": "0.2.58",
             "port-version": 1,
             "git-tree": "c47d47d390b2bced88a0c9272250b80acf214f11"


### PR DESCRIPTION
Bumps matterfirpc from 0.2.58 to 0.2.59.

Tagged commit: `f49e2aa0d8b93eaead5f85ed1295d3fb98b4c143` (Merge PR #346 — ME-974 Adjust Solana's structure to match the pattern adopted for other chains)