### PR TITLE
Add libcput 0.2.0 port

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -1,0 +1,23 @@
+# Linux builds need system libatspi2.0-dev and pkg-config for libcput's AT-SPI probe.
+vcpkg_from_git(
+  OUT_SOURCE_PATH SOURCE_PATH
+  URL https://github.com/matterfi/libcput.git
+  REF 41fc747ee09effa234407cc175c0fb57ea99a52c
+  HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    -DBUILD_TESTING=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME libcput CONFIG_PATH lib/cmake/libcput)
+
+file(
+  REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,0 +1,17 @@
+{
+    "name": "libcput",
+    "version": "0.2.0",
+    "port-version": 0,
+    "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
+    "homepage": "https://github.com/matterfi/libcput",
+    "dependencies": [
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        },
+        {
+            "name": "vcpkg-cmake-config",
+            "host": true
+        }
+    ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -16,6 +16,10 @@
             "baseline": "1.0.4",
             "port-version": 0
         },
+        "libcput": {
+            "baseline": "0.2.0",
+            "port-version": 0
+        },
         "opentxs": {
             "baseline": "1.264.0",
             "port-version": 0

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d56046f1196d51ba048c38b8e0a313549153ff5a",
+      "version": "0.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds the libcput 0.2.0 port.

- ports/libcput: vcpkg_from_git from matterfi/libcput @ 41fc747ee09effa234407cc175c0fb57ea99a52c; installs libcput::libcput (BUILD_TESTING=OFF).
- Validated locally: vcpkg install libcput builds debug+release and exports libcput::libcput.
- versions/ + baseline updated for libcput 0.2.0.