### PR TITLE
Bump matterfirpc version to 0.2.60

### DIFF
--- a/ports/matterfirpc/portfile.cmake
+++ b/ports/matterfirpc/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_git(
   URL
   ssh://git@github.com/matterfi/matterfirpc.git
   REF
-  f49e2aa0d8b93eaead5f85ed1295d3fb98b4c143
+  6776ac320a1ba88d9312991e228b17df6b0bb441
   HEAD_REF
   master)
 

--- a/ports/matterfirpc/vcpkg.json
+++ b/ports/matterfirpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "matterfirpc",
-    "version": "0.2.59",
+    "version": "0.2.60",
     "port-version": 0,
     "features": {
         "deploy": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -21,7 +21,7 @@
             "port-version": 0
         },
         "matterfirpc": {
-            "baseline": "0.2.59",
+            "baseline": "0.2.60",
             "port-version": 0
         }
     }

--- a/versions/m-/matterfirpc.json
+++ b/versions/m-/matterfirpc.json
@@ -1,6 +1,11 @@
 {
     "versions": [
         {
+            "version": "0.2.60",
+            "port-version": 0,
+            "git-tree": "e6930b2afdac8164037c6e938908defe0e1320a5"
+        },
+        {
             "version": "0.2.59",
             "port-version": 0,
             "git-tree": "31483450629e2e36debbc8ca4a3777eda79f9fe1"


### PR DESCRIPTION
Bumps the matterfirpc port to version 0.2.60.

- REF updated to `6776ac320a1ba88d9312991e228b17df6b0bb441` (latest on master, Merge PR #352)
- `ports/matterfirpc/vcpkg.json` version -> 0.2.60
- `versions/m-/matterfirpc.json` new entry with git-tree `e6930b2afdac8164037c6e938908defe0e1320a5`
- `versions/baseline.json` baseline -> 0.2.60