### PR TITLE
Bump libcput to port-version 1 (shared-library support)

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL https://github.com/matterfi/libcput.git
-  REF 41fc747ee09effa234407cc175c0fb57ea99a52c
+  REF cdd03ff4672453346464ccaaa977857232d27529
   HEAD_REF main
 )
 

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "name": "libcput",
     "version": "0.2.0",
-    "port-version": 0,
+    "port-version": 1,
     "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
     "homepage": "https://github.com/matterfi/libcput",
     "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
         },
         "libcput": {
             "baseline": "0.2.0",
-            "port-version": 0
+            "port-version": 1
         },
         "opentxs": {
             "baseline": "1.264.0",

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45047a3c6661a6bcad2f629658b796670672409b",
+      "version": "0.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d56046f1196d51ba048c38b8e0a313549153ff5a",
       "version": "0.2.0",
       "port-version": 0


### PR DESCRIPTION
Bumps the libcput port to `0.2.0` port-version 1, pointing at
`matterfi/libcput@cdd03ff`, which adds `BUILD_SHARED_LIBS` support (and Windows
DLL symbol export via `WINDOWS_EXPORT_ALL_SYMBOLS`).

Changes:
- `ports/libcput/portfile.cmake`: REF `41fc747` → `cdd03ff`
- `ports/libcput/vcpkg.json` + `versions/baseline.json` + `versions/l-/libcput.json`: port-version 0 → 1

`libcput@cdd03ff` is CI-green on Linux, macOS, and Windows × {shared, static}:
https://github.com/dhalman/libcput/actions/runs/28279764423

Follow-up (separate change): flip af-wallet's `vcpkg-configuration.json` libcput
registry pin from the temporary `dhalman/vcpkg-registry` to `matterfi/vcpkg-registry`
once this lands.
