### PR TITLE
Add libcput 0.3.0 (shared-library support)

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL https://github.com/matterfi/libcput.git
-  REF 41fc747ee09effa234407cc175c0fb57ea99a52c
+  REF 30f87cf72a806a6a94cbe52a5f6a4c26b4926b40
   HEAD_REF main
 )
 

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,17 +1,16 @@
 {
-    "name": "libcput",
-    "version": "0.2.0",
-    "port-version": 0,
-    "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
-    "homepage": "https://github.com/matterfi/libcput",
-    "dependencies": [
-        {
-            "name": "vcpkg-cmake",
-            "host": true
-        },
-        {
-            "name": "vcpkg-cmake-config",
-            "host": true
-        }
-    ]
+  "name": "libcput",
+  "version": "0.3.0",
+  "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
+  "homepage": "https://github.com/matterfi/libcput",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1,32 +1,32 @@
 {
-    "default": {
-        "boost-container": {
-            "baseline": "1.85.0",
-            "port-version": 100
-        },
-        "boost-move": {
-            "baseline": "1.85.0",
-            "port-version": 99
-        },
-        "botan": {
-            "baseline": "3.7.1",
-            "port-version": 1
-        },
-        "caspersdk": {
-            "baseline": "1.0.4",
-            "port-version": 0
-        },
-        "libcput": {
-            "baseline": "0.2.0",
-            "port-version": 0
-        },
-        "opentxs": {
-            "baseline": "1.265.2",
-            "port-version": 0
-        },
-        "matterfirpc": {
-            "baseline": "0.2.60",
-            "port-version": 0
-        }
+  "default": {
+    "boost-container": {
+      "baseline": "1.85.0",
+      "port-version": 100
+    },
+    "boost-move": {
+      "baseline": "1.85.0",
+      "port-version": 99
+    },
+    "botan": {
+      "baseline": "3.7.1",
+      "port-version": 1
+    },
+    "caspersdk": {
+      "baseline": "1.0.4",
+      "port-version": 0
+    },
+    "libcput": {
+      "baseline": "0.3.0",
+      "port-version": 0
+    },
+    "matterfirpc": {
+      "baseline": "0.2.60",
+      "port-version": 0
+    },
+    "opentxs": {
+      "baseline": "1.265.2",
+      "port-version": 0
     }
+  }
 }

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54ac2866bde4b8b6ce72e1356fcfe89bc4bf392b",
+      "version": "0.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d56046f1196d51ba048c38b8e0a313549153ff5a",
       "version": "0.2.0",
       "port-version": 0


### PR DESCRIPTION
Adds **libcput 0.3.0** — the shared-library release.

Supersedes #203, redone per review: a proper **version bump (0.3.0)** referencing a
**tagged release**, instead of a port-version bump pinned to a raw commit.

- `ports/libcput/vcpkg.json`: version → `0.3.0`
- `ports/libcput/portfile.cmake`: REF → `matterfi/libcput@30f87cf` (tag `v0.3.0`) —
  adds `BUILD_SHARED_LIBS` + Windows DLL export (`WINDOWS_EXPORT_ALL_SYMBOLS`)
- `versions/` regenerated with `vcpkg x-add-version` (git-tree `54ac2866`, verified consistent)

libcput is CI-green on Linux, macOS, and Windows × {shared, static}:
https://github.com/dhalman/libcput/actions/runs/28279764423

Follow-up (separate change): flip af-wallet's `vcpkg-configuration.json` libcput pin
from the temporary `dhalman/vcpkg-registry` to `matterfi/vcpkg-registry` once this lands.
