### PR TITLE
Bump matterfirpc version to 0.2.61

### DIFF
--- a/ports/matterfirpc/portfile.cmake
+++ b/ports/matterfirpc/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_git(
   URL
   ssh://git@github.com/matterfi/matterfirpc.git
   REF
-  6776ac320a1ba88d9312991e228b17df6b0bb441
+  cf785fdfd8e95e48e800a9d97db29fe1360a7863
   HEAD_REF
   master)
 

--- a/ports/matterfirpc/vcpkg.json
+++ b/ports/matterfirpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "matterfirpc",
-    "version": "0.2.60",
+    "version": "0.2.61",
     "port-version": 0,
     "features": {
         "deploy": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -21,7 +21,7 @@
       "port-version": 0
     },
     "matterfirpc": {
-      "baseline": "0.2.60",
+      "baseline": "0.2.61",
       "port-version": 0
     },
     "opentxs": {

--- a/versions/m-/matterfirpc.json
+++ b/versions/m-/matterfirpc.json
@@ -1,6 +1,11 @@
 {
     "versions": [
         {
+            "version": "0.2.61",
+            "port-version": 0,
+            "git-tree": "866a71e0b4fa88fa4c795e8913aa924aa84d18b3"
+        },
+        {
             "version": "0.2.60",
             "port-version": 0,
             "git-tree": "e6930b2afdac8164037c6e938908defe0e1320a5"


### PR DESCRIPTION
Bumps the matterfirpc port to version 0.2.61.

Fixes the static-library export bug from 0.2.60: matterfirpc linked `nlohmann_json` PRIVATE, which a static lib still propagated to consumers as `$<LINK_ONLY:nlohmann_json::nlohmann_json>`, forcing every consumer to define that target (broke wallet after it dropped nlohmann). 0.2.61 wraps it in `$<BUILD_INTERFACE:>` so nlohmann is gone from the exported interface.

- REF updated to `cf785fdfd8e95e48e800a9d97db29fe1360a7863` (master, Merge PR #353)
- `ports/matterfirpc/vcpkg.json` version -> 0.2.61
- `versions/m-/matterfirpc.json` new entry, git-tree `866a71e0b4fa88fa4c795e8913aa924aa84d18b3`
- `versions/baseline.json` baseline -> 0.2.61