### PR TITLE
[libcput] update to 0.3.1

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL https://github.com/matterfi/libcput.git
-  REF 30f87cf72a806a6a94cbe52a5f6a4c26b4926b40
+  REF d74b6d7d553c330a9561c28173b3251fd280e6d9
   HEAD_REF main
 )
 

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcput",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
   "homepage": "https://github.com/matterfi/libcput",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,7 +17,7 @@
       "port-version": 0
     },
     "libcput": {
-      "baseline": "0.3.0",
+      "baseline": "0.3.1",
       "port-version": 0
     },
     "matterfirpc": {

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4582e21cc297511b3ee4cc81abfca07869b0fe7b",
+      "version": "0.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "54ac2866bde4b8b6ce72e1356fcfe89bc4bf392b",
       "version": "0.3.0",
       "port-version": 0


### PR DESCRIPTION
Bumps the libcput port to v0.3.1 (matterfi/libcput@d74b6d7, tag v0.3.1).

v0.3.1 adds event-driven dismissal awaits (no more thread-sleep poll in the macOS await path) and the `--local` passthrough flag. Uses `vcpkg_from_git` REF bump — no SHA512 change. Versions DB + baseline updated to 0.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)