### PR TITLE
libcput 0.3.4

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL https://github.com/matterfi/libcput.git
-  REF d74b6d7d553c330a9561c28173b3251fd280e6d9
+  REF fd3187e5d3bad61af11c88cc962db7bdd377a7ed
   HEAD_REF main
 )
 

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcput",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
   "homepage": "https://github.com/matterfi/libcput",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,7 +17,7 @@
       "port-version": 0
     },
     "libcput": {
-      "baseline": "0.3.1",
+      "baseline": "0.3.4",
       "port-version": 0
     },
     "matterfirpc": {

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "764dc6d8ac0acdbc412843028af8667bc2d166c5",
+      "version": "0.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "4582e21cc297511b3ee4cc81abfca07869b0fe7b",
       "version": "0.3.1",
       "port-version": 0


### PR DESCRIPTION
Bumps libcput to 0.3.4.

- pin matterfi/libcput@fd3187e5d3bad61af11c88cc962db7bdd377a7ed
- update version database
- update baseline
