### PR TITLE
Update libcput to 0.3.5

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL https://github.com/matterfi/libcput.git
-  REF fd3187e5d3bad61af11c88cc962db7bdd377a7ed
+  REF 18a1c1aa9863cb0aca0302ae0f6471ad52c97260
   HEAD_REF main
 )
 

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcput",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
   "homepage": "https://github.com/matterfi/libcput",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,7 +17,7 @@
       "port-version": 0
     },
     "libcput": {
-      "baseline": "0.3.4",
+      "baseline": "0.3.5",
       "port-version": 0
     },
     "matterfirpc": {

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76152ced1d1f1205bf8e45fc0b5b6bc1481e8bf4",
+      "version": "0.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "764dc6d8ac0acdbc412843028af8667bc2d166c5",
       "version": "0.3.4",
       "port-version": 0


### PR DESCRIPTION
Uses signed libcput v0.3.5 for simulator-backed wallet onboarding tests.

Tests: four wallet onboarding skins passed in parallel against wallet commit 41f57d1b.