### PR TITLE
Update libcput to 0.3.6

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL https://github.com/matterfi/libcput.git
-  REF 18a1c1aa9863cb0aca0302ae0f6471ad52c97260
+  REF 2bf6b649cb30172871248c7afaa1940a59e4774d
   HEAD_REF main
 )
 
@@ -21,3 +21,8 @@ file(
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(
+  WRITE
+  "${CURRENT_PACKAGES_DIR}/share/libcput/LIBCPUT_SHA.txt"
+  "2bf6b649cb30172871248c7afaa1940a59e4774d\n"
+)

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcput",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
   "homepage": "https://github.com/matterfi/libcput",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,7 +17,7 @@
       "port-version": 0
     },
     "libcput": {
-      "baseline": "0.3.5",
+      "baseline": "0.3.6",
       "port-version": 0
     },
     "matterfirpc": {

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8dcb866c5773c97621bc57efc92c2091fc138cf9",
+      "version": "0.3.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "76152ced1d1f1205bf8e45fc0b5b6bc1481e8bf4",
       "version": "0.3.5",
       "port-version": 0


### PR DESCRIPTION
Pin libcput 0.3.6 to the verified merged commit 2bf6b649 and install a SHA receipt for consumers that require exact provenance.