### PR TITLE
Fix automerge for fork pull requests

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,7 +1,7 @@
 name: automerge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
Fork pull requests use the trusted base workflow so GITHUB_TOKEN can enable auto-merge.