### PR TITLE
Fix libcput SSH source fetch

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -1,7 +1,7 @@
 # Linux builds need system libatspi2.0-dev and pkg-config for libcput's AT-SPI probe.
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
-  URL https://github.com/matterfi/libcput.git
+  URL ssh://git@github.com/matterfi/libcput.git
   REF 2bf6b649cb30172871248c7afaa1940a59e4774d
   HEAD_REF main
 )

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libcput",
   "version": "0.3.6",
+  "port-version": 1,
   "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
   "homepage": "https://github.com/matterfi/libcput",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "libcput": {
       "baseline": "0.3.6",
-      "port-version": 0
+      "port-version": 1
     },
     "matterfirpc": {
       "baseline": "0.2.62",

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "902cc159a107e780e7c8180de1586ece6502007c",
+      "version": "0.3.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "8dcb866c5773c97621bc57efc92c2091fc138cf9",
       "version": "0.3.6",
       "port-version": 0


### PR DESCRIPTION
- Use SSH credentials for the private libcput source.
- Publish unchanged `0.3.6` source as `0.3.6#1`.

Tests:
- uncached `vcpkg install libcput:arm64-osx`
- installed SHA `2bf6b649cb30172871248c7afaa1940a59e4774d`
- HTTPS no-credential negative control