### PR TITLE
Update libcput to 0.4.0

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL ssh://git@github.com/matterfi/libcput.git
-  REF 2bf6b649cb30172871248c7afaa1940a59e4774d
+  REF 116e7d90370a4ae29c21d302ba1e87d3ac529628
   HEAD_REF main
 )
 
@@ -24,5 +24,5 @@ vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(
   WRITE
   "${CURRENT_PACKAGES_DIR}/share/libcput/LIBCPUT_SHA.txt"
-  "2bf6b649cb30172871248c7afaa1940a59e4774d\n"
+  "116e7d90370a4ae29c21d302ba1e87d3ac529628\n"
 )

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libcput",
-  "version": "0.3.6",
-  "port-version": 1,
+  "version": "0.3.9",
   "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
   "homepage": "https://github.com/matterfi/libcput",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,8 +17,8 @@
       "port-version": 0
     },
     "libcput": {
-      "baseline": "0.3.6",
-      "port-version": 1
+      "baseline": "0.3.9",
+      "port-version": 0
     },
     "matterfirpc": {
       "baseline": "0.2.63",

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,6 +1,21 @@
 {
   "versions": [
     {
+      "git-tree": "bcb7d95cf2981c376f3e542ae74b31678354ae4c",
+      "version": "0.3.9",
+      "port-version": 0
+    },
+    {
+      "git-tree": "c8532a449dc811e09cddb8b04016526d26049e6f",
+      "version": "0.3.8",
+      "port-version": 0
+    },
+    {
+      "git-tree": "d081c7c7b62c112ebcfd0cfb28b58044dd940f1a",
+      "version": "0.3.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "902cc159a107e780e7c8180de1586ece6502007c",
       "version": "0.3.6",
       "port-version": 1


### PR DESCRIPTION
Adds Linux per-character keyboard support and process/socket cleanup on failure/hang/kill