### PR TITLE
Update libcput to 0.4.0

### DIFF
--- a/ports/libcput/portfile.cmake
+++ b/ports/libcput/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL ssh://git@github.com/matterfi/libcput.git
-  REF 116e7d90370a4ae29c21d302ba1e87d3ac529628
+  REF b09dd45f37578b005d92088427994fb838b97938
   HEAD_REF main
 )
 
@@ -24,5 +24,5 @@ vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(
   WRITE
   "${CURRENT_PACKAGES_DIR}/share/libcput/LIBCPUT_SHA.txt"
-  "116e7d90370a4ae29c21d302ba1e87d3ac529628\n"
+  "b09dd45f37578b005d92088427994fb838b97938\n"
 )

--- a/ports/libcput/vcpkg.json
+++ b/ports/libcput/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcput",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "Cross-platform UI-test harness library with a UIDriver contract and platform accessibility adapters.",
   "homepage": "https://github.com/matterfi/libcput",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,7 +17,7 @@
       "port-version": 0
     },
     "libcput": {
-      "baseline": "0.3.9",
+      "baseline": "0.4.0",
       "port-version": 0
     },
     "matterfirpc": {

--- a/versions/l-/libcput.json
+++ b/versions/l-/libcput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b15aec8d4bbf43c3f91b183e81355d6fc206dedf",
+      "version": "0.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bcb7d95cf2981c376f3e542ae74b31678354ae4c",
       "version": "0.3.9",
       "port-version": 0


### PR DESCRIPTION
Updates libcput to 0.4.0 for simulator-backed wallet CPUT tests.