### PR TITLE
Bump matterfirpc version to 1.1.0

### DIFF
--- a/ports/matterfirpc/portfile.cmake
+++ b/ports/matterfirpc/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_git(
   URL
   ssh://git@github.com/matterfi/matterfirpc.git
   REF
-  143dd7515d65a0ceeeda2cfb5a2ac4279807a7f3
+  e45e89a6b8acf34ee493bdd9ba2bea539646c5b2
   HEAD_REF
   master)
 
@@ -14,7 +14,6 @@ vcpkg_check_features(
   OUT_FEATURE_OPTIONS FEATURE_OPTIONS
   FEATURES
     deploy        MATTERFIRPC_ENABLE_DEPLOY
-    privacy-cash  MATTERFIRPC_ENABLE_PRIVACY_CASH
 )
 
 vcpkg_cmake_configure(

--- a/ports/matterfirpc/vcpkg.json
+++ b/ports/matterfirpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "matterfirpc",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "port-version": 0,
     "features": {
         "deploy": {
@@ -12,9 +12,6 @@
                     "platform": "!(android | ios)"
                 }
             ]
-        },
-        "privacy-cash": {
-            "description": "Enable privacy cash support"
         },
         "test": {
             "description": "Build tests",
@@ -82,11 +79,6 @@
                 "matterfi",
                 "noparallel"
             ]
-        },
-        {
-            "name": "libsodium",
-            "default-features": false,
-            "version>=": "1.0.19#4"
         },
         {
             "name": "magic-enum",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -21,7 +21,7 @@
       "port-version": 0
     },
     "matterfirpc": {
-      "baseline": "1.0.0",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "opentxs": {

--- a/versions/m-/matterfirpc.json
+++ b/versions/m-/matterfirpc.json
@@ -1,6 +1,11 @@
 {
     "versions": [
         {
+            "version": "1.1.0",
+            "port-version": 0,
+            "git-tree": "49ee30b28a578251562f00b5c4dac6524d92ca17"
+        },
+        {
             "version": "1.0.0",
             "port-version": 0,
             "git-tree": "c9634299ff76e2eef5fcba5c9e358c3d9795e291"


### PR DESCRIPTION
It's an intermediate version 1.1.0. I will start to follow semantic versioning after this last one.
It's for adjusting a wallet client to use the changed API of Solana's mattefiRPC.

The next bump will be to matterfirpc 2.0.0, which will use opentxs v2.0.0 with added new feutures like base58 or recoverable signing.