### PR TITLE
matterfirpc: restore privacy-cash feature, bump to 1.1.0#1

### DIFF
--- a/ports/matterfirpc/portfile.cmake
+++ b/ports/matterfirpc/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_check_features(
   OUT_FEATURE_OPTIONS FEATURE_OPTIONS
   FEATURES
     deploy        MATTERFIRPC_ENABLE_DEPLOY
+    privacy-cash  MATTERFIRPC_ENABLE_PRIVACY_CASH
 )
 
 vcpkg_cmake_configure(

--- a/ports/matterfirpc/vcpkg.json
+++ b/ports/matterfirpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "name": "matterfirpc",
     "version": "1.1.0",
-    "port-version": 0,
+    "port-version": 1,
     "features": {
         "deploy": {
             "description": "Implement Contract::deploy",
@@ -12,6 +12,9 @@
                     "platform": "!(android | ios)"
                 }
             ]
+        },
+        "privacy-cash": {
+            "description": "Enable privacy cash support (requires ts-node and npm)"
         },
         "test": {
             "description": "Build tests",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -22,7 +22,7 @@
     },
     "matterfirpc": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opentxs": {
       "baseline": "2.0.0",

--- a/versions/m-/matterfirpc.json
+++ b/versions/m-/matterfirpc.json
@@ -2,6 +2,11 @@
     "versions": [
         {
             "version": "1.1.0",
+            "port-version": 1,
+            "git-tree": "9ca76f2dc5d28aaa7a2ed8495390a936366e3331"
+        },
+        {
+            "version": "1.1.0",
             "port-version": 0,
             "git-tree": "49ee30b28a578251562f00b5c4dac6524d92ca17"
         },


### PR DESCRIPTION
Restores the privacy-cash vcpkg feature that was accidentally dropped during the 1.0.0->1.1.0 port bump. Without this mapping in vcpkg_check_features, CMake sees the default ON from CMakeLists.txt and requires ts-node/npm at configure time, breaking builds on macOS and Windows where those tools are not installed.

Users who need privacy cash can opt in via matterfirpc[privacy-cash].