### PR TITLE
Bump matterfirpc version to 1.2.0

### DIFF
--- a/ports/matterfirpc/portfile.cmake
+++ b/ports/matterfirpc/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_git(
   URL
   ssh://git@github.com/matterfi/matterfirpc.git
   REF
-  e45e89a6b8acf34ee493bdd9ba2bea539646c5b2
+  a9d4f0a82ecdcee3e27820be3afcdd884f896f14
   HEAD_REF
   master)
 

--- a/ports/matterfirpc/vcpkg.json
+++ b/ports/matterfirpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "name": "matterfirpc",
-    "version": "1.1.0",
-    "port-version": 1,
+    "version": "1.2.0",
+    "port-version": 0,
     "features": {
         "deploy": {
             "description": "Implement Contract::deploy",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -21,8 +21,8 @@
       "port-version": 0
     },
     "matterfirpc": {
-      "baseline": "1.1.0",
-      "port-version": 1
+      "baseline": "1.2.0",
+      "port-version": 0
     },
     "opentxs": {
       "baseline": "2.0.0",

--- a/versions/m-/matterfirpc.json
+++ b/versions/m-/matterfirpc.json
@@ -1,6 +1,11 @@
 {
     "versions": [
         {
+            "version": "1.2.0",
+            "port-version": 0,
+            "git-tree": "99d4b20c9213ca1d704be9c1efb58c7f115f6d93"
+        },
+        {
             "version": "1.1.0",
             "port-version": 1,
             "git-tree": "9ca76f2dc5d28aaa7a2ed8495390a936366e3331"


### PR DESCRIPTION
matterfirpc 1.2.0:
* adds opentxs external wrapper header (upgrade to opentxs v2.0.0)
* fixes matterfirpc manual tests