### PR TITLE
Bump matterfirpc to 1.2.1

### DIFF
--- a/ports/matterfirpc/portfile.cmake
+++ b/ports/matterfirpc/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_git(
   URL
   ssh://git@github.com/matterfi/matterfirpc.git
   REF
-  e45e89a6b8acf34ee493bdd9ba2bea539646c5b2
+  faa936cb753f1d4580b6d5942795d2a09ea56952
   HEAD_REF
   master)
 

--- a/ports/matterfirpc/vcpkg.json
+++ b/ports/matterfirpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "name": "matterfirpc",
-    "version": "1.1.0",
-    "port-version": 1,
+    "version": "1.2.1",
+    "port-version": 0,
     "features": {
         "deploy": {
             "description": "Implement Contract::deploy",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -21,8 +21,8 @@
       "port-version": 0
     },
     "matterfirpc": {
-      "baseline": "1.1.0",
-      "port-version": 1
+      "baseline": "1.2.1",
+      "port-version": 0
     },
     "opentxs": {
       "baseline": "2.0.0",

--- a/versions/m-/matterfirpc.json
+++ b/versions/m-/matterfirpc.json
@@ -1,6 +1,16 @@
 {
     "versions": [
         {
+            "version": "1.2.1",
+            "port-version": 0,
+            "git-tree": "09736273b476d983c8aae88f1dde72518979761a"
+        },
+        {
+            "version": "1.2.0",
+            "port-version": 0,
+            "git-tree": "99d4b20c9213ca1d704be9c1efb58c7f115f6d93"
+        },
+        {
             "version": "1.1.0",
             "port-version": 1,
             "git-tree": "9ca76f2dc5d28aaa7a2ed8495390a936366e3331"


### PR DESCRIPTION
matterfirpc 1.2.1:
* adds opentxs external wrapper header (upgrade to opentxs v2.0.0)
* fixes matterfirpc manual tests
* Fixes missing installation of `matterfirpc/external/opentxs.hpp` public header

